### PR TITLE
Proposal: Support alternative acronym separator '|'

### DIFF
--- a/src/main/java/com/xdesign/hackronym/event/AppHomeListener.java
+++ b/src/main/java/com/xdesign/hackronym/event/AppHomeListener.java
@@ -47,6 +47,10 @@ public class AppHomeListener implements BoltEventHandler<AppHomeOpenedEvent> {
 						divider(), section( section -> section.text( markdownText( mt -> mt.text(
 								"Just type a sentence with an acronym and i'll decipher the acronyms!\n" ) ) ) ),
 						divider(), section( section -> section.text( markdownText( mt -> mt.text(
-								"Command Examples:\n" + "/whatis ASAP\n" + "/getall\n" + "/addacronym ASAP,As Soon As Possible,Something is needed really fast.\n" + "/removeacronym ASAP\n" ) ) ) ) ) ) );
+								"Command Examples:\n" + "/whatis ASAP\n" + "/getall\n" + "/addacronym ASAP,As Soon As Possible,Something is needed really fast.\n" + "/removeacronym ASAP\n" ) ) ) ),
+						divider(), section( section -> section.text( markdownText( mt -> mt.text(
+								"Note that the `/addacronym` command requires three sections - the acronym, the short meaning, and longer description\n" +
+								"If you need to have commas in any of these sections you can use the `|` symbol to separate them rather than the `,`, e.g\n" +
+								"`/addacronym PICNIC|Problem In Chair, Not In Computer|Indicates that the user is the problem, not the software\n") ) ) ) ) ) );
 	}
 }

--- a/src/main/java/com/xdesign/hackronym/slash/acronym/parser/AcronymParser.java
+++ b/src/main/java/com/xdesign/hackronym/slash/acronym/parser/AcronymParser.java
@@ -4,14 +4,38 @@ import org.springframework.stereotype.Component;
 
 import com.xdesign.hackronym.domain.Acronym;
 
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 @Component
 public class AcronymParser {
-	public Acronym parse( final String message ) {
-		final String[] params = message.split( "," );
-		return Acronym.builder()
-				.acronym( params[0] )
-				.meaning( params[1] )
-				.description( params[2] )
-				.build();
+	private static final Pattern PSV_RX = Pattern.compile("^(?<acronym>[^|]+)\\|(?<meaning>[^|]+)\\|(?<description>[^|]+)$");
+	private static final Pattern CSV_RX = Pattern.compile("^(?<acronym>[^,]+),(?<meaning>[^,]+),(?<description>.+)$");
+
+	public Acronym parse(final String message) {
+		return parsePSV(message)
+				.or(() -> parseCSV(message))
+				.orElseThrow(IllegalArgumentException::new);
+	}
+
+	private Optional<Acronym> parsePSV(final String message ) {
+		return attemptParseAs(PSV_RX, message);
+	}
+
+	private Optional<Acronym> parseCSV(final String message) {
+		return attemptParseAs(CSV_RX, message);
+	}
+
+	private Optional<Acronym> attemptParseAs(final Pattern pattern, final String message) {
+		return Optional.ofNullable(message)
+				.map(pattern::matcher)
+				.filter(Matcher::matches)
+				.map(m -> Acronym.builder()
+						.acronym(m.group("acronym"))
+						.meaning(m.group("meaning"))
+						.description(m.group("description"))
+				)
+				.map(Acronym.AcronymBuilder::build);
 	}
 }

--- a/src/test/java/com/xdesign/hackronym/slash/acronym/parser/AcronymParserTest.java
+++ b/src/test/java/com/xdesign/hackronym/slash/acronym/parser/AcronymParserTest.java
@@ -28,4 +28,31 @@ class AcronymParserTest {
 		assertThat( acronym.getMeaning() ).isEqualTo( "As soon as" );
 		assertThat( acronym.getDescription() ).isEqualTo( "very quickly" );
 	}
+
+	@Test
+	void shouldReturnAnAcronymFromSuppliedMessageWithCommasInDescription() {
+		final Acronym acronym = acronymParser.parse( "ASAP,As soon as,very quickly, or whatever" );
+
+		assertThat( acronym.getAcronym() ).isEqualTo( "ASAP" );
+		assertThat( acronym.getMeaning() ).isEqualTo( "As soon as" );
+		assertThat( acronym.getDescription() ).isEqualTo( "very quickly, or whatever" );
+	}
+
+	@Test
+	void shouldSupportAlternativeSeparator() {
+		final Acronym acronym = acronymParser.parse( "ASAP|As soon as|very quickly" );
+
+		assertThat( acronym.getAcronym() ).isEqualTo( "ASAP" );
+		assertThat( acronym.getMeaning() ).isEqualTo( "As soon as" );
+		assertThat( acronym.getDescription() ).isEqualTo( "very quickly" );
+	}
+
+	@Test
+	void shouldSupportCommasInDescription() {
+		final Acronym acronym = acronymParser.parse("PICNIC|Problem In Chair, Not In Computer|Indicates that I/we/you/they caused the problem, and the software is fine. .");
+
+		assertThat( acronym.getAcronym() ).isEqualTo( "PICNIC" );
+		assertThat( acronym.getMeaning() ).isEqualTo( "Problem In Chair, Not In Computer" );
+		assertThat( acronym.getDescription() ).isEqualTo( "Indicates that I/we/you/they caused the problem, and the software is fine. ." );
+	}
 }


### PR DESCRIPTION
(For an alternative proposal, see #2 ).

Adds support for:

* Alternative acronym separator (using pipe symbol)
* When using traditional separator, commas are allowed in the description

This _does_ have the effect of slackening validation slightly where the choice is ambiguous (for example, where a definition contains a mixture of pipes and commas and could be taken as either, or where there is a comma in the description but one of the fields has been omitted accidentally), but submitting as a proposal anyway as I feel "liberal in what you accept" is probably worthwhile here (due to potential for unschooled user input and ease of removal by slash command).