### PR TITLE
Alternative proposal: full CSV support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'com.slack.api:bolt-servlet:1.10.0'
     implementation 'com.slack.api:bolt-jetty:1.10.0'
 	implementation 'com.google.guava:guava:31.1-jre'
+	implementation 'com.opencsv:opencsv:5.5'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/xdesign/hackronym/slash/acronym/parser/AcronymParser.java
+++ b/src/main/java/com/xdesign/hackronym/slash/acronym/parser/AcronymParser.java
@@ -1,17 +1,33 @@
 package com.xdesign.hackronym.slash.acronym.parser;
 
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
 import org.springframework.stereotype.Component;
 
 import com.xdesign.hackronym.domain.Acronym;
 
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+import java.util.Optional;
+
 @Component
 public class AcronymParser {
 	public Acronym parse( final String message ) {
-		final String[] params = message.split( "," );
-		return Acronym.builder()
-				.acronym( params[0] )
-				.meaning( params[1] )
-				.description( params[2] )
-				.build();
+		try {
+			final var csv = new CSVReader(new StringReader(Objects.requireNonNull(message)));
+			return Optional.ofNullable(csv.readNext())
+					.map(fields -> Acronym.builder()
+							.acronym(fields[0])
+							.meaning(fields[1])
+							.description(fields[2])
+							.build())
+					.orElseThrow(IllegalArgumentException::new);
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		} catch (CsvValidationException e) {
+			throw new IllegalArgumentException(String.format("Malformed input: %s", message), e);
+		}
 	}
 }

--- a/src/test/java/com/xdesign/hackronym/slash/acronym/parser/AcronymParserTest.java
+++ b/src/test/java/com/xdesign/hackronym/slash/acronym/parser/AcronymParserTest.java
@@ -28,4 +28,13 @@ class AcronymParserTest {
 		assertThat( acronym.getMeaning() ).isEqualTo( "As soon as" );
 		assertThat( acronym.getDescription() ).isEqualTo( "very quickly" );
 	}
+
+	@Test
+	void shouldSupportEscapedCommasInAllFields() {
+		final Acronym acronym = acronymParser.parse( "\"PIC,NIC\", \"Problem In Chair, Not In Computer\", \"Testing, Commas\"");
+
+		assertThat( acronym.getAcronym() ).isEqualTo( "PIC,NIC" );
+		assertThat( acronym.getMeaning() ).isEqualTo( "Problem In Chair, Not In Computer" );
+		assertThat( acronym.getDescription() ).isEqualTo( "Testing, Commas" );
+	}
 }


### PR DESCRIPTION
This proposal is an alternative to #1 - here, no alternative separator is used, and instead the input is parsed as CSV (with support for escaping and whatnot).
